### PR TITLE
`chazz sync` command to (automatically) send changes to a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,10 @@ You get an interactive shell with the appropriate key pre-loaded in an SSH agent
 So you can type `ssh $HB` to connect or `scp -r example $HB:` to upload files.
 Or to run a specific command, pass it as an argument, as in `chazz shell 'scp something.c $HB:'`.
 
+It can get a little annoying to edit files on the VM, so Chazz can help synchronize files you edit locally.
+Type `chazz sync foo` to [rsync][] `foo` to the server.
+
 Use the `--ami` option to choose a specific AMI ID to connect to or launch.
 As a shorthand, you can also use `-iN` to choose the `N`th image---for example, `chazz -i1 list` will show instances using the second image in our built-in list.
+
+[rsync]: https://www.samba.org/rsync/

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ Or to run a specific command, pass it as an argument, as in `chazz shell 'scp so
 
 It can get a little annoying to edit files on the VM, so Chazz can help synchronize files you edit locally.
 Type `chazz sync foo` to [rsync][] `foo` to the server.
+The `-w` flag uses [entr][] to watch for changes to files and automatically send them to the server.
 
 Use the `--ami` option to choose a specific AMI ID to connect to or launch.
 As a shorthand, you can also use `-iN` to choose the `N`th image---for example, `chazz -i1 list` will show instances using the second image in our built-in list.
 
 [rsync]: https://www.samba.org/rsync/
+[entr]: http://entrproject.org


### PR DESCRIPTION
I got tired of editing files on the server, or manually copying them, so `chazz sync somedir` will now rsync files to the server for you. Or, even better, `chazz sync -w somedir` will wait for changes in that directory, so whenever you save a file, it automatically gets copied up to the server. To use this, you'll need to install the [entr](http://entrproject.org) command.