### PR TITLE
 Replace entr with watchexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ There is also a `chazz start` command, which is like `chazz ssh` in that it ensu
 
 It can get a little annoying to edit files on the VM, so Chazz can help synchronize files you edit locally.
 Type `chazz sync foo` to [rsync][] `foo` to the server.
-The `-w` flag uses [entr][] to watch for changes to files and automatically send them to the server.
+The `-w` flag uses [watchexec][] to watch for changes to files and automatically send them to the server.
 
 ### Get a Shell for Typing Arbitrary SSH Commands
 
@@ -103,4 +103,4 @@ There are a few global command-line flags you can use:
 * `-i`: A shorthand to pick an AMI from our built-in list. Use the version name string. For example, `-i v0.4.2` will start and connect to instances using that version of the image.
 
 [rsync]: https://www.samba.org/rsync/
-[entr]: http://entrproject.org
+[watchexec]: https://github.com/watchexec/watchexec

--- a/chazz/__init__.py
+++ b/chazz/__init__.py
@@ -396,15 +396,10 @@ def sync(config, src, dest, watch):
     ]
 
     if watch:
-        # Use entr(1) to watch for changes.
-        find_cmd = ['find', src]
-        entr_cmd = ['entr'] + rsync_cmd
-        log.info('{} | {}'.format(fmt_cmd(find_cmd), fmt_cmd(entr_cmd)))
-
-        find_proc = subprocess.Popen(find_cmd, stdout=subprocess.PIPE)
-        entr_proc = subprocess.Popen(entr_cmd, stdin=find_proc.stdout)
-        find_proc.stdout.close()
-        entr_proc.wait()
+        # Use `watchexec` to watch for changes.
+        we_cmd = ['watchexec', '-w', src, '--'] + rsync_cmd
+        log.info(fmt_cmd(we_cmd))
+        subprocess.run(we_cmd)
 
     else:
         # Just rsync once.

--- a/chazz/__init__.py
+++ b/chazz/__init__.py
@@ -397,7 +397,7 @@ def sync(config, src, dest, watch):
 
     if watch:
         # Use `watchexec` to watch for changes.
-        we_cmd = ['watchexec', '-w', src, '--'] + rsync_cmd
+        we_cmd = ['watchexec', '-w', src, '-n', '--'] + rsync_cmd
         log.info(fmt_cmd(we_cmd))
         subprocess.run(we_cmd)
 


### PR DESCRIPTION
This replaces the file-watching tool that implements `chazz sync -w`. It used to be [entr][]; now it's [watchexec][].

[entr]: http://eradman.com/entrproject/
[watchexec]: https://github.com/watchexec/watchexec

entr is a little annoying in its insistence that it doesn't crawl directories, which makes it pretty irritating to watch for when *new* files are added to a directory. This meant that `chazz sync -w` would pick up changes to old files but not upload any new files you create. watchexec just has the searching built in and can trigger a command when *anything* happens in a directory. This fixes the new-file problem.